### PR TITLE
Change DataTemplate to IDataTemplate to allow ViewLocator pattern for…

### DIFF
--- a/src/Behaviors/OverlayWindowBehavior.cs
+++ b/src/Behaviors/OverlayWindowBehavior.cs
@@ -6,6 +6,7 @@ using NP.Utilities;
 using System;
 using System.Collections.Immutable;
 using System.Threading.Tasks;
+using Avalonia.Controls.Templates;
 
 namespace NP.Ava.Visuals.Behaviors
 {
@@ -68,18 +69,18 @@ namespace NP.Ava.Visuals.Behaviors
 
 
         #region ContentTemplate Attached Avalonia Property
-        public static DataTemplate GetContentTemplate(Control obj)
+        public static IDataTemplate GetContentTemplate(Control obj)
         {
             return obj.GetValue(ContentTemplateProperty);
         }
 
-        public static void SetContentTemplate(Control obj, DataTemplate value)
+        public static void SetContentTemplate(Control obj, IDataTemplate value)
         {
             obj.SetValue(ContentTemplateProperty, value);
         }
 
-        public static readonly AttachedProperty<DataTemplate> ContentTemplateProperty =
-            AvaloniaProperty.RegisterAttached<OverlayWindowBehavior, Control, DataTemplate>
+        public static readonly AttachedProperty<IDataTemplate> ContentTemplateProperty =
+            AvaloniaProperty.RegisterAttached<OverlayWindowBehavior, Control, IDataTemplate>
             (
                 "ContentTemplate"
             );

--- a/src/Controls/CustomWindow.cs
+++ b/src/Controls/CustomWindow.cs
@@ -28,6 +28,7 @@ using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Avalonia.Controls.Templates;
 
 namespace NP.Ava.Visuals.Controls
 {
@@ -575,14 +576,14 @@ namespace NP.Ava.Visuals.Controls
         #endregion HeaderContent Styled Avalonia Property
 
         #region HeaderContentTemplate Styled Avalonia Property
-        public DataTemplate HeaderContentTemplate
+        public IDataTemplate HeaderContentTemplate
         {
             get { return GetValue(HeaderContentTemplateProperty); }
             set { SetValue(HeaderContentTemplateProperty, value); }
         }
 
-        public static readonly StyledProperty<DataTemplate> HeaderContentTemplateProperty =
-            AvaloniaProperty.Register<CustomWindow, DataTemplate>
+        public static readonly StyledProperty<IDataTemplate> HeaderContentTemplateProperty =
+            AvaloniaProperty.Register<CustomWindow, IDataTemplate>
             (
                 nameof(HeaderContentTemplate)
             );
@@ -651,14 +652,14 @@ namespace NP.Ava.Visuals.Controls
         #endregion TitleAreaContent Styled Avalonia Property
 
         #region TitleAreaContentTemplate Styled Avalonia Property
-        public DataTemplate TitleAreaContentTemplate
+        public IDataTemplate TitleAreaContentTemplate
         {
             get { return GetValue(TitleAreaContentTemplateProperty); }
             set { SetValue(TitleAreaContentTemplateProperty, value); }
         }
 
-        public static readonly StyledProperty<DataTemplate> TitleAreaContentTemplateProperty =
-            AvaloniaProperty.Register<CustomWindow, DataTemplate>
+        public static readonly StyledProperty<IDataTemplate> TitleAreaContentTemplateProperty =
+            AvaloniaProperty.Register<CustomWindow, IDataTemplate>
             (
                 nameof(TitleAreaContentTemplate)
             );


### PR DESCRIPTION
… docking with MVVM

This is one part of the PR as requested in 
https://github.com/npolyak/NP.Ava.UniDock/issues/6

Changed code to use IDataTemplate instead of DataTemplate in order to make this work using a ViewLocator (see: [Avalonia Docs](https://docs.avaloniaui.net/docs/concepts/view-locator)